### PR TITLE
Some tiny updates about queue and shared_ptr

### DIFF
--- a/docs/memory/smart-pointer.md
+++ b/docs/memory/smart-pointer.md
@@ -21,7 +21,7 @@
 
 ## `#!cpp std::shared_ptr`
 
-`std::shared_ptr` 表示一个指针可能被多次引用，也就是存在着共享的关系。使用时应该使用 `std::shared_ptr` 来生成一个指向对象的 `std::shared_ptr`。`std::shared_ptr` 允许拷贝，在使用时直接使用按值传递的方式来使用即可，不需要使用 `std::move`。
+`std::shared_ptr` 表示一个指针可能被多次引用，也就是存在着共享的关系。使用时应该使用 `std::shared_ptr` 来生成一个指向对象的 `std::shared_ptr`。`std::shared_ptr` 允许拷贝，在使用时可以直接使用按值传递的方式来使用。
 
 `std::shared_ptr` 中内置了引用计数，当发生拷贝的时候就会给引用计数加一，析构函数则会减一。当引用计数为 0 说明这个指针已经无人使用了，就会调用对象的析构函数去释放内存。
 

--- a/docs/parallel/practice/multi-threading-queue.md
+++ b/docs/parallel/practice/multi-threading-queue.md
@@ -51,7 +51,7 @@ public:
     bool pop(T& element) {
         std::scoped_lock lock(m);
         if (!q.empty()) {
-            element = q.front();
+            element = std::move(q.front());
             q.pop();
             return true;
         }


### PR DESCRIPTION
* `docs/parallel/practice/multi-threading-queue.md` 俺感觉这个地方是不是加一个 move 比较好，因为例子里面 enqueue 的时候走了 move
* `docs/memory/smart-pointer.md` 感觉大部分时候 `std::shared_ptr` 还是不太好直接拷贝的，这里随便改了点